### PR TITLE
Rename KeyswitchEvent & KeyswitchState structures

### DIFF
--- a/src/model01/Keyboard.cpp
+++ b/src/model01/Keyboard.cpp
@@ -9,7 +9,7 @@
 #include "model01/Scanner.h"
 
 #include <kaleidoglyph/KeyState.h>
-#include <kaleidoglyph/KeyswitchEvent.h>
+#include <kaleidoglyph/KeyEvent.h>
 
 
 namespace kaleidoglyph {

--- a/src/model01/Keyboard.cpp
+++ b/src/model01/Keyboard.cpp
@@ -8,7 +8,7 @@
 #include "model01/LedAddr.h"
 #include "model01/Scanner.h"
 
-#include <kaleidoglyph/KeyswitchState.h>
+#include <kaleidoglyph/KeyState.h>
 #include <kaleidoglyph/KeyswitchEvent.h>
 
 
@@ -37,12 +37,12 @@ void Keyboard::scanMatrix() {
 }
 
 // return the state of the keyswitch as a bitfield
-KeyswitchState Keyboard::keyswitchState(KeyAddr k) const {
+KeyState Keyboard::keyswitchState(KeyAddr k) const {
   byte state = 0;
   byte r = byte(k) / 8;
   byte c = byte(k) % 8;
-  return KeyswitchState(bitRead(curr_scan_.banks[r], c),
-                        bitRead(prev_scan_.banks[r], c));
+  return KeyState(bitRead(curr_scan_.banks[r], c),
+                  bitRead(prev_scan_.banks[r], c));
 }
 
 

--- a/src/model01/Keyboard.h
+++ b/src/model01/Keyboard.h
@@ -10,7 +10,7 @@
 #include "model01/KeyAddr.h"
 #include "model01/Scanner.h"
 
-#include <kaleidoglyph/KeyswitchState.h>
+#include <kaleidoglyph/KeyState.h>
 #include <kaleidoglyph/KeyswitchEvent.h>
 #include <kaleidoglyph/cKeyAddr.h>
 #include <kaleidoglyph/cKey.h>
@@ -31,7 +31,7 @@ class Keyboard {
   void scanMatrix();
 
   // I really don't think we need this function, but maybe it will be useful
-  KeyswitchState keyswitchState(KeyAddr k) const;
+  KeyState keyswitchState(KeyAddr k) const;
 
   // Update all LEDs to values set by set*Color() functions below
   void updateLeds();
@@ -138,7 +138,7 @@ inline bool Keyboard::Iterator::operator!=(const Iterator& other) {
 
           event_.addr  = KeyAddr(addr_);
           event_.key   = cKey::blank;
-          event_.state = KeyswitchState(curr_state, prev_state);
+          event_.state = KeyState(curr_state, prev_state);
 
           // The `event_` will be returned by the dereference operator below, to be used
           // in the body of the loop:

--- a/src/model01/Keyboard.h
+++ b/src/model01/Keyboard.h
@@ -11,7 +11,7 @@
 #include "model01/Scanner.h"
 
 #include <kaleidoglyph/KeyState.h>
-#include <kaleidoglyph/KeyswitchEvent.h>
+#include <kaleidoglyph/KeyEvent.h>
 #include <kaleidoglyph/cKeyAddr.h>
 #include <kaleidoglyph/cKey.h>
 
@@ -93,14 +93,14 @@ class Keyboard {
 
     bool operator!=(const Iterator& other);
 
-    KeyswitchEvent& operator*();
+    KeyEvent& operator*();
 
     void operator++();
 
    private:
     Keyboard& keyboard_;
     byte addr_;
-    KeyswitchEvent event_;
+    KeyEvent event_;
 
   }; // class Iterator {
 
@@ -157,7 +157,7 @@ inline bool Keyboard::Iterator::operator!=(const Iterator& other) {
   return false;
 }
 
-inline KeyswitchEvent& Keyboard::Iterator::operator*() {
+inline KeyEvent& Keyboard::Iterator::operator*() {
   return event_;
 }
 
@@ -169,7 +169,7 @@ inline void Keyboard::Iterator::operator++() {
 #if 0
 // To use the Keyboard::Iterator, write a loop like the following:
 Keyboard keyboard;
-for (KeyswitchEvent event : keyboard) {
+for (KeyEvent event : keyboard) {
   // Here you'll get an `event` for each keyswitch that changed state in the current scan
   // cycle, and only those keyswitches, so most of the time the code in this block won't
   // execute at all.


### PR DESCRIPTION
I'm trying to make a distinction between events that are physical-only (Keyswitch*) and the more general events that can be software-only (Key*), in advance of changing the hooks available in the event handler loop.

See gedankenlab/Kaleidoglyph-Core#14